### PR TITLE
test[#29]: agregar pruebas unitarias para check_pr.py

### DIFF
--- a/tests/test_check_pr.py
+++ b/tests/test_check_pr.py
@@ -1,0 +1,18 @@
+import os
+import tempfile
+from scripts.check_pr import validar_titulo
+
+# Verifica que el titulo de PR tiene el formato correcto
+def test_titulo_valido():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pr_id = "123"
+        carpeta_pr = os.path.join(temp_dir, pr_id)
+        os.makedirs(carpeta_pr)
+        archivo = os.path.join(carpeta_pr, f"pr_{pr_id}_title.txt")
+
+        with open(archivo, "w", encoding="utf-8") as f:
+            f.write("PROY-123: primer pull request")
+
+        ok, msg = validar_titulo(carpeta_pr)
+        assert ok is True
+        assert msg == "OK"

--- a/tests/test_check_pr.py
+++ b/tests/test_check_pr.py
@@ -90,3 +90,21 @@ def test_commits_todos_validos():
         ok, errores = validar_commits(carpeta_pr)
         assert ok is True
         assert errores == []
+
+# Test para verificar que los commits tienen errores de formato
+def test_commits_con_errores():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        carpeta_pr = os.path.join(temp_dir, "128")
+        os.makedirs(carpeta_pr)
+
+        commits = """commit sin formato
+                    feat123: falta corchetes
+                    fix[#789]: commit correcto"""
+        with open(os.path.join(carpeta_pr, "commits.txt"), "w", encoding="utf-8") as f:
+            f.write(commits)
+
+        ok, errores = validar_commits(carpeta_pr)
+        assert ok is False
+        assert len(errores) == 2
+        assert "fila 1" in errores[0]
+        assert "fila 2" in errores[1]

--- a/tests/test_check_pr.py
+++ b/tests/test_check_pr.py
@@ -1,9 +1,9 @@
 import os
 import tempfile
-from scripts.check_pr import validar_titulo
+from scripts.check_pr import validar_titulo, verificar_changelog
 
 
-# Verifica que el titulo de PR tiene el formato correcto
+# Test para verificar que el titulo de PR tiene el formato correcto
 def test_titulo_valido():
     with tempfile.TemporaryDirectory() as temp_dir:
         pr_id = "123"
@@ -18,7 +18,7 @@ def test_titulo_valido():
         assert ok is True
 
 
-# verificar que el titulo de PR no tiene el formato correcto
+# Test para verificar que el titulo de PR no tiene el formato correcto
 def test_titulo_mal_formato():
     with tempfile.TemporaryDirectory() as temp_dir:
         pr_id = "124"
@@ -31,3 +31,23 @@ def test_titulo_mal_formato():
 
         ok, msg = validar_titulo(carpeta_pr)
         assert ok is False
+
+# test para verificar que el archivo CHANGELOG.md contiene la seccion del PR actual
+def test_changelog_contiene_pr():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pr_id = "125"
+        carpeta_pr = os.path.join(temp_dir, pr_id)
+        os.makedirs(carpeta_pr)
+
+        changelog_path = os.path.join(temp_dir, "CHANGELOG.md")
+        with open(changelog_path, "w", encoding="utf-8") as f:
+            f.write(f"# Cambios\n\n## PR {pr_id}\n- test PR\n")
+
+        carpeta_actual = os.getcwd()
+        os.chdir(os.path.join(temp_dir, pr_id))
+        try:
+            ok, _ = verificar_changelog(carpeta_pr)
+        finally:
+            os.chdir(carpeta_actual)
+
+        assert ok

--- a/tests/test_check_pr.py
+++ b/tests/test_check_pr.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 from scripts.check_pr import validar_titulo
 
+
 # Verifica que el titulo de PR tiene el formato correcto
 def test_titulo_valido():
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -15,4 +16,18 @@ def test_titulo_valido():
 
         ok, msg = validar_titulo(carpeta_pr)
         assert ok is True
-        assert msg == "OK"
+
+
+# verificar que el titulo de PR no tiene el formato correcto
+def test_titulo_mal_formato():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pr_id = "124"
+        carpeta_pr = os.path.join(temp_dir, pr_id)
+        os.makedirs(carpeta_pr)
+        archivo = os.path.join(carpeta_pr, f"pr_{pr_id}_title.txt")
+
+        with open(archivo, "w", encoding="utf-8") as f:
+            f.write("PR que no tiene el formato correcto")  # Mal formato
+
+        ok, msg = validar_titulo(carpeta_pr)
+        assert ok is False

--- a/tests/test_check_pr.py
+++ b/tests/test_check_pr.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-from scripts.check_pr import validar_titulo, verificar_changelog
+from scripts.check_pr import validar_titulo, verificar_changelog, validar_commits
 
 
 # Test para verificar que el titulo de PR tiene el formato correcto
@@ -73,3 +73,20 @@ def test_changelog_sin_seccion():
             os.chdir(carpeta_actual)
 
         assert ok is False
+
+
+# Test para verificar que los commits tienen el formato correcto
+def test_commits_todos_validos():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        carpeta_pr = os.path.join(temp_dir, "127")
+        os.makedirs(carpeta_pr)
+
+        commits = """feat[#123]: primer commit
+                    fix[#124]: segundo commit
+                    refactor[#125]: tercer commit"""
+        with open(os.path.join(carpeta_pr, "commits.txt"), "w", encoding="utf-8") as f:
+            f.write(commits)
+
+        ok, errores = validar_commits(carpeta_pr)
+        assert ok is True
+        assert errores == []

--- a/tests/test_check_pr.py
+++ b/tests/test_check_pr.py
@@ -32,6 +32,7 @@ def test_titulo_mal_formato():
         ok, msg = validar_titulo(carpeta_pr)
         assert ok is False
 
+
 # test para verificar que el archivo CHANGELOG.md contiene la seccion del PR actual
 def test_changelog_contiene_pr():
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -51,3 +52,24 @@ def test_changelog_contiene_pr():
             os.chdir(carpeta_actual)
 
         assert ok
+
+
+# test para verificar que el archivo CHANGELOG.md no contiene la seccion del PR actual
+def test_changelog_sin_seccion():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        pr_id = "126"
+        carpeta_pr = os.path.join(temp_dir, pr_id)
+        os.makedirs(carpeta_pr)
+
+        changelog_path = os.path.join(temp_dir, "CHANGELOG.md")
+        with open(changelog_path, "w", encoding="utf-8") as f:
+            f.write("# Cambios\n\n## PR 999\n- test PR\n")
+
+        carpeta_actual = os.getcwd()
+        os.chdir(carpeta_pr)
+        try:
+            ok, msg = verificar_changelog(carpeta_pr)
+        finally:
+            os.chdir(carpeta_actual)
+
+        assert ok is False


### PR DESCRIPTION
Este PR agrega pruebas unitarias para las funciones de validacion definidas en `check_pr.py`, incluyendo la verificacion del titulo, los commits y el archivo `CHANGELOG.md`.
